### PR TITLE
Add new overlay for INT environment

### DIFF
--- a/infra/application/overlays/int/deployment.yaml
+++ b/infra/application/overlays/int/deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentic-bizdevops
+spec:
+  replicas: 2

--- a/infra/application/overlays/int/kustomization.yaml
+++ b/infra/application/overlays/int/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+commonLabels:
+  env: int
+
+resources:
+  - ../../base/
+
+patchesStrategicMerge:
+  - service.yaml
+  - deployment.yaml
+
+configMapGenerator:
+  - name: application-configmap
+    behavior: merge
+    literals:
+      - INFO_APP_ENV=int

--- a/infra/application/overlays/int/service.yaml
+++ b/infra/application/overlays/int/service.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentic-bizdevops
+spec:
+  type: LoadBalancer


### PR DESCRIPTION
This PR implements GitHub Issue #9 by adding a Kustomize overlay for the integration environment.

The following changes were made:
1. Created a new overlay named `int` in the `infra/application/overlays` directory
2. Set environment-specific labels (env: int)
3. Changed replica count to 2 in the deployment
4. Changed service type to LoadBalancer
5. Added environment-specific configuration (INFO_APP_ENV=int)

All requirements from the issue have been implemented.

Closes #9