### PR TITLE
Implement Fibonacci REST endpoint with separate controller

### DIFF
--- a/src/main/java/dev/kernelkaput/ai/FibonacciController.java
+++ b/src/main/java/dev/kernelkaput/ai/FibonacciController.java
@@ -1,0 +1,39 @@
+package dev.kernelkaput.ai;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Controller class for calculating Fibonacci numbers.
+ * Separated from the REST resource for clean separation of concerns.
+ */
+@ApplicationScoped
+public class FibonacciController {
+    
+    /**
+     * Calculate the Fibonacci number at the given position.
+     * 
+     * @param position the position in the Fibonacci sequence (0-based index)
+     * @return the Fibonacci number at the specified position
+     * @throws IllegalArgumentException if position is negative
+     */
+    public long calculateFibonacci(int position) {
+        if (position < 0) {
+            throw new IllegalArgumentException("Position must be non-negative");
+        }
+        
+        if (position <= 1) {
+            return position;
+        }
+        
+        long prev = 0;
+        long current = 1;
+        
+        for (int i = 2; i <= position; i++) {
+            long next = prev + current;
+            prev = current;
+            current = next;
+        }
+        
+        return current;
+    }
+}

--- a/src/main/java/dev/kernelkaput/ai/FibonacciResource.java
+++ b/src/main/java/dev/kernelkaput/ai/FibonacciResource.java
@@ -1,0 +1,48 @@
+package dev.kernelkaput.ai;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST resource for the Fibonacci endpoint.
+ */
+@Path("/fibonacci")
+public class FibonacciResource {
+
+    private final FibonacciController fibonacciController;
+
+    @Inject
+    public FibonacciResource(FibonacciController fibonacciController) {
+        this.fibonacciController = fibonacciController;
+    }
+
+    /**
+     * Returns the Fibonacci number at the specified position.
+     * 
+     * @param position the position in the Fibonacci sequence (required)
+     * @return Response containing the Fibonacci number or error message
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getFibonacci(@QueryParam("position") Integer position) {
+        if (position == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Query parameter 'position' is required")
+                    .build();
+        }
+        
+        try {
+            long result = fibonacciController.calculateFibonacci(position);
+            return Response.ok().entity(result).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/native-test/java/dev/kernelkaput/ai/FibonacciResourceIT.java
+++ b/src/native-test/java/dev/kernelkaput/ai/FibonacciResourceIT.java
@@ -1,0 +1,8 @@
+package dev.kernelkaput.ai;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class FibonacciResourceIT extends FibonacciResourceTest {
+    // Execute the same tests but in packaged mode.
+}

--- a/src/test/java/dev/kernelkaput/ai/FibonacciControllerTest.java
+++ b/src/test/java/dev/kernelkaput/ai/FibonacciControllerTest.java
@@ -1,0 +1,44 @@
+package dev.kernelkaput.ai;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FibonacciControllerTest {
+
+    private final FibonacciController controller = new FibonacciController();
+
+    @Test
+    void testThrowsExceptionForNegativePosition() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
+            () -> controller.calculateFibonacci(-1));
+        
+        assertEquals("Position must be non-negative", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0, 0",
+        "1, 1",
+        "2, 1",
+        "3, 2", 
+        "4, 3",
+        "5, 5",
+        "6, 8",
+        "7, 13",
+        "10, 55",
+        "20, 6765"
+    })
+    void testCalculateFibonacci(int position, long expected) {
+        assertEquals(expected, controller.calculateFibonacci(position));
+    }
+    
+    @Test
+    void testHandleLargePositionWithoutOverflow() {
+        // Test with larger values to ensure we don't have overflow issues
+        long result = controller.calculateFibonacci(50);
+        assertEquals(12586269025L, result);
+    }
+}

--- a/src/test/java/dev/kernelkaput/ai/FibonacciResourceTest.java
+++ b/src/test/java/dev/kernelkaput/ai/FibonacciResourceTest.java
@@ -1,0 +1,47 @@
+package dev.kernelkaput.ai;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class FibonacciResourceTest {
+
+    @Test
+    void testMissingPositionParameter() {
+        given()
+            .when().get("/fibonacci")
+            .then()
+                .statusCode(400)
+                .body(is("Query parameter 'position' is required"));
+    }
+
+    @Test
+    void testNegativePositionParameter() {
+        given()
+            .when().get("/fibonacci?position=-1")
+            .then()
+                .statusCode(400)
+                .body(is("Position must be non-negative"));
+    }
+
+    @Test
+    void testZeroPositionParameter() {
+        given()
+            .when().get("/fibonacci?position=0")
+            .then()
+                .statusCode(200)
+                .body(is("0"));
+    }
+
+    @Test
+    void testPosition10Parameter() {
+        given()
+            .when().get("/fibonacci?position=10")
+            .then()
+                .statusCode(200)
+                .body(is("55"));
+    }
+}


### PR DESCRIPTION
This PR implements GitHub Issue #5 by adding a new REST endpoint for calculating Fibonacci numbers.

The implementation includes:
- A `FibonacciController` class with business logic for calculating Fibonacci numbers
- A `FibonacciResource` REST endpoint that accepts a `position` parameter
- Comprehensive unit tests for both the controller and resource
- Integration tests for the endpoint

The endpoint can be accessed at `/fibonacci?position=n` where n is the position in the Fibonacci sequence (0-based).

Closes #5